### PR TITLE
fix for Issue #2 loop reference

### DIFF
--- a/EntityTest.Test/EntityTest.Test.csproj
+++ b/EntityTest.Test/EntityTest.Test.csproj
@@ -63,6 +63,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="General\RecursionTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PropertySetValidatorTests\ActualOnlyValidationTests.cs" />
     <Compile Include="PropertySetValidatorTests\AliasNamespaceTests.cs" />

--- a/EntityTest.Test/General/RecursionTests.cs
+++ b/EntityTest.Test/General/RecursionTests.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using EntityTest.Test.PropertySetValidatorTests.TestObjects;
+using NUnit.Framework;
+using TestMonkeys.EntityTest;
+using TestMonkeys.EntityTest.Framework;
+
+namespace EntityTest.Test.General
+{
+    public class RecursionTests
+    {
+        public class ObjectWithRecursiveRef
+        {
+            [ChildEntity]
+            public ObjectWithRecursiveRef RecursiveRef { get; set; }
+
+            [ChildEntity]
+            public ChildWithRefToParent ChildWithRefToParent { get; set; }
+
+            public int IntValue { get; set; }
+        }
+
+        public class ChildWithRefToParent
+        {
+            [ChildEntity]
+            public ObjectWithRecursiveRef ParentRef { get; set; }
+        }
+
+        //[Ignore("Recursion Issue")]
+        [Test]
+        public void PropertySet_RecursiveReference_Level0()
+        {
+            var expected = new ObjectWithRecursiveRef {IntValue = 1};
+            expected.RecursiveRef = expected;
+            var actual = new ObjectWithRecursiveRef {IntValue = 1};
+            actual.RecursiveRef = actual;
+            Assert.That(actual,Entity.EqualTo(expected));
+        }
+        //[Ignore("Recursion Issue")]
+        [Test]
+        public void PropertySet_RecursiveReference_Level1()
+        {
+            var expected = new ObjectWithRecursiveRef { IntValue = 1 };
+            expected.ChildWithRefToParent = new ChildWithRefToParent {ParentRef = expected};
+            var actual = new ObjectWithRecursiveRef { IntValue = 1 };
+            actual.ChildWithRefToParent = new ChildWithRefToParent { ParentRef = actual };
+            Assert.That(actual, Entity.EqualTo(expected));
+        }
+    }
+}

--- a/EntityTest.Test/General/RecursionTests.cs
+++ b/EntityTest.Test/General/RecursionTests.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using EntityTest.Test.PropertySetValidatorTests.TestObjects;
+﻿using EntityTest.Test.PropertySetValidatorTests;
 using NUnit.Framework;
 using TestMonkeys.EntityTest;
 using TestMonkeys.EntityTest.Framework;
@@ -11,6 +7,96 @@ namespace EntityTest.Test.General
 {
     public class RecursionTests
     {
+        [Test]
+        public void PropertySet_Compare_RecursiveReference_Level0()
+        {
+            var expected = new ObjectWithRecursiveRef {IntValue = 1};
+            expected.RecursiveRef = expected;
+            var actual = new ObjectWithRecursiveRef {IntValue = 1};
+            actual.RecursiveRef = actual;
+            Assert.That(actual, Entity.EqualTo(expected));
+        }
+
+        [Test]
+        public void PropertySet_Compare_RecursiveReference_Negative_ExpectedNull_Level0()
+        {
+            var expected = new ObjectWithRecursiveRef
+            {
+                IntValue = 1,
+                RecursiveRef = null
+            };
+            var actual = new ObjectWithRecursiveRef {IntValue = 1};
+            actual.RecursiveRef = actual;
+            var messageCheck = new MessageCheck("Property Set is not equal");
+            messageCheck.AddPropertyLine("Null", typeof (ObjectWithRecursiveRef).FullName, "RecursiveRef");
+            var ex = Assert.Throws(typeof (AssertionException),
+                () =>
+                    Assert.That(actual, Entity.EqualTo(expected)));
+            messageCheck.Check(ex);
+        }
+
+        [Test]
+        public void PropertySet_Compare_RecursiveReference_Negative_ActualNull_Level0()
+        {
+            var expected = new ObjectWithRecursiveRef {IntValue = 1};
+            expected.RecursiveRef = expected;
+            var actual = new ObjectWithRecursiveRef
+            {
+                IntValue = 1,
+                RecursiveRef = null
+            };
+            var messageCheck = new MessageCheck("Property Set is not equal");
+            messageCheck.AddPropertyLine(typeof (ObjectWithRecursiveRef).FullName, "Null", "RecursiveRef");
+            var ex = Assert.Throws(typeof (AssertionException),
+                () =>
+                    Assert.That(actual, Entity.EqualTo(expected)));
+            messageCheck.Check(ex);
+        }
+
+        [Test]
+        public void PropertySet_Compare_RecursiveReference_Negative_RecursiveOnlyInActual_Level0()
+        {
+            var expected = new ObjectWithRecursiveRef {IntValue = 1};
+            expected.RecursiveRef = new ObjectWithRecursiveRef {IntValue = 2};
+            var actual = new ObjectWithRecursiveRef {IntValue = 1};
+            actual.RecursiveRef = actual;
+            var messageCheck = new MessageCheck("Property Set is not equal");
+            messageCheck.AddPropertyLine("Null", typeof (ObjectWithRecursiveRef).FullName, "RecursiveRef.RecursiveRef");
+            messageCheck.AddPropertyLine("2", "1", "RecursiveRef.IntValue");
+            var ex = Assert.Throws(typeof (AssertionException),
+                () =>
+                    Assert.That(actual, Entity.EqualTo(expected)));
+            messageCheck.Check(ex);
+        }
+
+        [Test]
+        public void PropertySet_Compare_RecursiveReference_Negative_RecursiveOnlyInExpected_Level0()
+        {
+            var expected = new ObjectWithRecursiveRef {IntValue = 1};
+            expected.RecursiveRef = expected;
+            var actual = new ObjectWithRecursiveRef {IntValue = 1};
+            actual.RecursiveRef = new ObjectWithRecursiveRef {IntValue = 2};
+            var messageCheck = new MessageCheck("Property Set is not equal");
+            messageCheck.AddPropertyLine(typeof (ObjectWithRecursiveRef).FullName, "Null", "RecursiveRef.RecursiveRef");
+            messageCheck.AddPropertyLine("1", "2", "RecursiveRef.IntValue");
+            var ex = Assert.Throws(typeof (AssertionException),
+                () =>
+                    Assert.That(actual, Entity.EqualTo(expected)));
+            messageCheck.Check(ex);
+        }
+
+        [Test]
+        public void PropertySet_Compare_RecursiveReference_Level1()
+        {
+            var expected = new ObjectWithRecursiveRef {IntValue = 1};
+            expected.ChildWithRefToParent = new ChildWithRefToParent {ParentRef = expected};
+            var actual = new ObjectWithRecursiveRef {IntValue = 1};
+            actual.ChildWithRefToParent = new ChildWithRefToParent {ParentRef = actual};
+            Assert.That(actual, Entity.EqualTo(expected));
+        }
+
+        
+
         public class ObjectWithRecursiveRef
         {
             [ChildEntity]
@@ -28,25 +114,6 @@ namespace EntityTest.Test.General
             public ObjectWithRecursiveRef ParentRef { get; set; }
         }
 
-        //[Ignore("Recursion Issue")]
-        [Test]
-        public void PropertySet_RecursiveReference_Level0()
-        {
-            var expected = new ObjectWithRecursiveRef {IntValue = 1};
-            expected.RecursiveRef = expected;
-            var actual = new ObjectWithRecursiveRef {IntValue = 1};
-            actual.RecursiveRef = actual;
-            Assert.That(actual,Entity.EqualTo(expected));
-        }
-        //[Ignore("Recursion Issue")]
-        [Test]
-        public void PropertySet_RecursiveReference_Level1()
-        {
-            var expected = new ObjectWithRecursiveRef { IntValue = 1 };
-            expected.ChildWithRefToParent = new ChildWithRefToParent {ParentRef = expected};
-            var actual = new ObjectWithRecursiveRef { IntValue = 1 };
-            actual.ChildWithRefToParent = new ChildWithRefToParent { ParentRef = actual };
-            Assert.That(actual, Entity.EqualTo(expected));
-        }
+      
     }
 }

--- a/EntityTest/Engine/PropertyRuleSet/ParentContext.cs
+++ b/EntityTest/Engine/PropertyRuleSet/ParentContext.cs
@@ -35,6 +35,8 @@ namespace TestMonkeys.EntityTest.Engine.PropertyRuleSet
 
         public string ParentName { get; set; }
         public int? Index { get; set; }
+        public object ActualObj { get; set; }
+
 
         public ParentContext WithProprety(string propertyName)
         {
@@ -66,6 +68,12 @@ namespace TestMonkeys.EntityTest.Engine.PropertyRuleSet
             if (Index.HasValue)
                 sb.Append("[").Append(Index.Value).Append("]");
             return sb.ToString();
+        }
+
+        public bool IsRecursive(object actual)
+        {
+            if (parent == null) return false;
+            return actual.Equals(parent.ActualObj) || parent.IsRecursive(actual);
         }
     }
 }

--- a/EntityTest/Engine/PropertyRuleSet/Strategies/PropertyMatchingStrategy.cs
+++ b/EntityTest/Engine/PropertyRuleSet/Strategies/PropertyMatchingStrategy.cs
@@ -43,6 +43,8 @@ namespace TestMonkeys.EntityTest.Engine.PropertyRuleSet.Strategies
             }
             var expected = GetPropertyValue(expectedProp, expectedObj);
             var actual = GetPropertyValue(actualProperty, actualObj);
+
+            
             if ((expected == null && actual != null) || (expected != null && actual == null))
             {
                 var result = new List<MatchResult>();
@@ -62,7 +64,12 @@ namespace TestMonkeys.EntityTest.Engine.PropertyRuleSet.Strategies
             }
             if (expected == null)
                 return new List<MatchResult>();
-
+            if (parentContext != null)
+            {
+                if (parentContext.IsRecursive(actual))
+                    return new List<MatchResult>();
+                parentContext.ActualObj = actual;
+            }
             return InternalValidate(actualProperty, actualObj, expectedObj, parentContext);
         }
 


### PR DESCRIPTION
Fixing Issue #2 by searching through parent context, for references to the actual object being compared.